### PR TITLE
🧪 Add unit tests for MessageUtil.formatTime

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
+            <artifactId>junit-jupiter</artifactId>
             <version>5.10.2</version>
             <scope>test</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,12 @@
             <version>1.20.4-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.10.2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/test/java/org/SSoggy/SSoggyPvP/util/MessageUtilTest.java
+++ b/src/test/java/org/SSoggy/SSoggyPvP/util/MessageUtilTest.java
@@ -1,0 +1,36 @@
+package org.SSoggy.SSoggyPvP.util;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class MessageUtilTest {
+
+    @Test
+    public void testFormatTime_zeroAndNegativeSeconds() {
+        assertEquals("0s", MessageUtil.formatTime(0), "0 seconds should format to '0s'");
+        assertEquals("0s", MessageUtil.formatTime(-5), "Negative seconds should format to '0s'");
+        assertEquals("0s", MessageUtil.formatTime(-3600), "Negative hours should format to '0s'");
+    }
+
+    @Test
+    public void testFormatTime_onlySeconds() {
+        assertEquals("1s", MessageUtil.formatTime(1), "1 second should format to '1s'");
+        assertEquals("59s", MessageUtil.formatTime(59), "59 seconds should format to '59s'");
+    }
+
+    @Test
+    public void testFormatTime_minutesAndSeconds() {
+        assertEquals("1m 0s", MessageUtil.formatTime(60), "60 seconds should format to '1m 0s'");
+        assertEquals("1m 5s", MessageUtil.formatTime(65), "65 seconds should format to '1m 5s'");
+        assertEquals("59m 59s", MessageUtil.formatTime(3599), "3599 seconds should format to '59m 59s'");
+    }
+
+    @Test
+    public void testFormatTime_hoursMinutesAndSeconds() {
+        assertEquals("1h 0s", MessageUtil.formatTime(3600), "3600 seconds should format to '1h 0s' as per current implementation");
+        assertEquals("1h 1m 5s", MessageUtil.formatTime(3665), "3665 seconds should format to '1h 1m 5s'");
+        assertEquals("2h 0s", MessageUtil.formatTime(7200), "7200 seconds should format to '2h 0s'");
+        assertEquals("2h 30m 45s", MessageUtil.formatTime(9045), "9045 seconds should format to '2h 30m 45s'");
+        assertEquals("24h 0s", MessageUtil.formatTime(86400), "86400 seconds should format to '24h 0s'");
+    }
+}

--- a/src/test/java/org/SSoggy/SSoggyPvP/util/MessageUtilTest.java
+++ b/src/test/java/org/SSoggy/SSoggyPvP/util/MessageUtilTest.java
@@ -3,7 +3,7 @@ package org.SSoggy.SSoggyPvP.util;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class MessageUtilTest {
+class MessageUtilTest {
 
     @Test
     public void testFormatTime_zeroAndNegativeSeconds() {

--- a/src/test/java/org/SSoggy/SSoggyPvP/util/MessageUtilTest.java
+++ b/src/test/java/org/SSoggy/SSoggyPvP/util/MessageUtilTest.java
@@ -6,7 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class MessageUtilTest {
 
     @Test
-    public void testFormatTime_zeroAndNegativeSeconds() {
+    void testFormatTime_zeroAndNegativeSeconds() {
         assertEquals("0s", MessageUtil.formatTime(0), "0 seconds should format to '0s'");
         assertEquals("0s", MessageUtil.formatTime(-5), "Negative seconds should format to '0s'");
         assertEquals("0s", MessageUtil.formatTime(-3600), "Negative hours should format to '0s'");


### PR DESCRIPTION
🎯 **What:** Missing tests for `MessageUtil.formatTime` addressed by introducing unit tests with JUnit 5.
📊 **Coverage:** Covered scenarios for zero and negative inputs, inputs containing only seconds, minutes and seconds, and hours, minutes, and seconds, including edge cases where middle units are zero.
✨ **Result:** Test coverage for this pure utility method is now established, ensuring future regressions are caught early.

---
*PR created automatically by Jules for task [10366336688389342696](https://jules.google.com/task/10366336688389342696) started by @SSoggyTacoMan*