### PR TITLE
🧪 test: add tests for CommandUtil.requirePlayer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,18 @@
             <version>1.20.4-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>5.8.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/test/java/org/SSoggy/SSoggyPvP/util/CommandUtilTest.java
+++ b/src/test/java/org/SSoggy/SSoggyPvP/util/CommandUtilTest.java
@@ -24,7 +24,7 @@ class CommandUtilTest {
     }
 
     @Test
-    public void testRequirePlayer_WithNonPlayer() {
+    void testRequirePlayer_WithNonPlayer() {
         // Arrange
         CommandSender mockSender = mock(CommandSender.class);
         String errorMessage = "You must be a player!";

--- a/src/test/java/org/SSoggy/SSoggyPvP/util/CommandUtilTest.java
+++ b/src/test/java/org/SSoggy/SSoggyPvP/util/CommandUtilTest.java
@@ -1,0 +1,41 @@
+package org.SSoggy.SSoggyPvP.util;
+
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+public class CommandUtilTest {
+
+    @Test
+    public void testRequirePlayer_WithPlayer() {
+        // Arrange
+        Player mockPlayer = mock(Player.class);
+        String errorMessage = "You must be a player!";
+
+        // Act
+        Player result = CommandUtil.requirePlayer(mockPlayer, errorMessage);
+
+        // Assert
+        assertNotNull(result, "Result should not be null when sender is a player");
+        assertEquals(mockPlayer, result, "Result should be the same player object");
+        verify(mockPlayer, never()).sendMessage(anyString());
+    }
+
+    @Test
+    public void testRequirePlayer_WithNonPlayer() {
+        // Arrange
+        CommandSender mockSender = mock(CommandSender.class);
+        String errorMessage = "You must be a player!";
+        String translatedError = org.bukkit.ChatColor.translateAlternateColorCodes('&', errorMessage);
+
+        // Act
+        Player result = CommandUtil.requirePlayer(mockSender, errorMessage);
+
+        // Assert
+        assertNull(result, "Result should be null when sender is not a player");
+        // Verify that the error message is sent (translated)
+        verify(mockSender).sendMessage(translatedError);
+    }
+}

--- a/src/test/java/org/SSoggy/SSoggyPvP/util/CommandUtilTest.java
+++ b/src/test/java/org/SSoggy/SSoggyPvP/util/CommandUtilTest.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
-public class CommandUtilTest {
+class CommandUtilTest {
 
     @Test
     public void testRequirePlayer_WithPlayer() {

--- a/src/test/java/org/SSoggy/SSoggyPvP/util/CommandUtilTest.java
+++ b/src/test/java/org/SSoggy/SSoggyPvP/util/CommandUtilTest.java
@@ -9,7 +9,7 @@ import static org.mockito.Mockito.*;
 class CommandUtilTest {
 
     @Test
-    public void testRequirePlayer_WithPlayer() {
+    void testRequirePlayer_WithPlayer() {
         // Arrange
         Player mockPlayer = mock(Player.class);
         String errorMessage = "You must be a player!";


### PR DESCRIPTION
🎯 **What:** Missing tests for `CommandUtil.requirePlayer` were added.
📊 **Coverage:** Covered both the happy path (sender is a `Player`) and the error path (sender is a non-player `CommandSender`).
✨ **Result:** Test coverage improved with a deterministic test that ensures accurate checks and expected error messaging, providing a safety net for future refactoring. Added required testing dependencies (`junit-jupiter` and `mockito-core`) to `pom.xml`.

---
*PR created automatically by Jules for task [10718877508661852663](https://jules.google.com/task/10718877508661852663) started by @SSoggyTacoMan*