### PR TITLE
🧪 test: Add edge case tests for MessageUtil.formatTime

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,19 +33,10 @@
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
+            <artifactId>junit-jupiter</artifactId>
             <version>5.10.1</version>
             <scope>test</scope>
         </dependency>
-
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.10.1</version>
-            <scope>test</scope>
-        </dependency>
-
-
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,21 @@
             <version>1.20.4-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.10.1</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.10.1</version>
+            <scope>test</scope>
+        </dependency>
+
+
     </dependencies>
 
     <build>

--- a/src/test/java/org/SSoggy/SSoggyPvP/util/MessageUtilTest.java
+++ b/src/test/java/org/SSoggy/SSoggyPvP/util/MessageUtilTest.java
@@ -1,0 +1,40 @@
+package org.SSoggy.SSoggyPvP.util;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class MessageUtilTest {
+
+    @Test
+    public void testFormatTime_Zero() {
+        assertEquals("0s", MessageUtil.formatTime(0));
+    }
+
+    @Test
+    public void testFormatTime_Negative() {
+        assertEquals("0s", MessageUtil.formatTime(-1));
+        assertEquals("0s", MessageUtil.formatTime(-3600));
+        assertEquals("0s", MessageUtil.formatTime(-60));
+    }
+
+    @Test
+    public void testFormatTime_PositiveSeconds() {
+        assertEquals("45s", MessageUtil.formatTime(45));
+        assertEquals("1s", MessageUtil.formatTime(1));
+        assertEquals("59s", MessageUtil.formatTime(59));
+    }
+
+    @Test
+    public void testFormatTime_PositiveMinutes() {
+        assertEquals("1m 5s", MessageUtil.formatTime(65));
+        assertEquals("1m 0s", MessageUtil.formatTime(60));
+        assertEquals("59m 59s", MessageUtil.formatTime(3599));
+    }
+
+    @Test
+    public void testFormatTime_PositiveHours() {
+        assertEquals("1h 1m 1s", MessageUtil.formatTime(3661));
+        assertEquals("1h 0s", MessageUtil.formatTime(3600));
+        assertEquals("2h 30m 45s", MessageUtil.formatTime(9045));
+    }
+}

--- a/src/test/java/org/SSoggy/SSoggyPvP/util/MessageUtilTest.java
+++ b/src/test/java/org/SSoggy/SSoggyPvP/util/MessageUtilTest.java
@@ -3,7 +3,7 @@ package org.SSoggy.SSoggyPvP.util;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class MessageUtilTest {
+class MessageUtilTest {
 
     @Test
     public void testFormatTime_Zero() {


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was the lack of edge case testing for `MessageUtil.formatTime`, particularly for negative values.
📊 **Coverage:** The new tests cover:
- Zero value (`0s`).
- Negative values, verifying they output `0s`.
- Positive combinations focusing on seconds, minutes, and hours logic.
✨ **Result:** Enhanced code reliability and coverage for utility time formatting by ensuring edge cases correctly default to `0s` instead of anomalous outputs.

---
*PR created automatically by Jules for task [16327467572844242317](https://jules.google.com/task/16327467572844242317) started by @SSoggyTacoMan*