### PR TITLE
🧹 Remove deprecated cleanupPlayer method from PlaytimeManager

### DIFF
--- a/src/main/java/org/SSoggy/SSoggyPvP/manager/PlaytimeManager.java
+++ b/src/main/java/org/SSoggy/SSoggyPvP/manager/PlaytimeManager.java
@@ -71,11 +71,6 @@ public class PlaytimeManager {
         if (saveTask != null) saveTask.cancel();
     }
     
-    @Deprecated(forRemoval = true, since = "1.0.0")
-    public void cleanupPlayer(UUID playerId) {
-        // no-op: throttling removed since task already runs at 1-second intervals
-    }
-
     private void updatePlayerTimesAndDebt() {
         // cache online player count once per tick instead of reading multiple times
         int onlinePlayerCount = Bukkit.getOnlinePlayers().size();


### PR DESCRIPTION
Removed the deprecated and unused `cleanupPlayer` method from `PlaytimeManager.java`. This method was a no-op and was no longer needed as the logic it previously handled is now managed by a periodic task. Replaced with an empty block in the file for better readability. Verified that no other part of the codebase calls this method.

---
*PR created automatically by Jules for task [11195760630960329880](https://jules.google.com/task/11195760630960329880) started by @SSoggyTacoMan*