### PR TITLE
🧹 Remove temporary simtime test command

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ A comprehensive Minecraft PvP management plugin that provides players with contr
 | `/pvpadmin player <name> info` | View player PvP information | `pvptoggle.admin` |
 | `/pvpadmin player <name> reset` | Reset player's PvP data | `pvptoggle.admin` |
 | `/pvpadmin player <name> setdebt <seconds>` | Set player's forced PvP debt | `pvptoggle.admin` |
-| `/pvpadmin simtime <seconds>` | Simulate playtime for testing | `pvptoggle.admin` |
 | `/pvpadmin reload` | Reload configuration | `pvptoggle.admin` |
 
 ## Permissions

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -114,14 +114,6 @@ Set a player's forced PvP debt directly.
 /pvpadmin player Steve setdebt 1200
 ```
 
-### `/pvpadmin simtime <seconds>`
-
-Add simulated playtime to the executing player for testing.
-
-```bash
-/pvpadmin simtime 3600
-```
-
 ### `/pvpadmin reload`
 
 Reload `config.yml` from disk.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -29,10 +29,10 @@ You must select two corners in the same world first.
 
 ## How do I test the playtime system quickly?
 
-Use the simulation command:
+You can test forced PvP debt by manually setting a player's debt:
 
 ```bash
-/pvpadmin simtime 3600
+/pvpadmin player <name> setdebt 1200
 ```
 
 ## Where is player data stored?

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,7 +37,7 @@ SSoggyPvP-Manager gives players direct control over their PvP status while givin
 2. Adjust `plugins/SSoggyPvP-Manager/config.yml`.
 3. Give admins access to `pvptoggle.admin`.
 4. Create a zone with `/pvpadmin wand` and `/pvpadmin zone create <name>`.
-5. Test forced PvP with `/pvp status` and `/pvpadmin simtime <seconds>`.
+5. Test forced PvP with `/pvp status`.
 
 ## Key Features
 

--- a/docs/playtime-system.md
+++ b/docs/playtime-system.md
@@ -47,20 +47,6 @@ messages:
 
 Players with `pvptoggle.bypass` are exempt from playtime-based forced PvP.
 
-## Testing
-
-Use the built-in simulation command to avoid waiting:
-
-```bash
-/pvpadmin simtime 3600
-```
-
-Then verify the result with:
-
-```bash
-/pvp status
-```
-
 ## Admin Inspection
 
 To inspect an affected player:

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -62,13 +62,7 @@ Join the server and run:
 
 ### Step 6: Test Playtime Debt
 
-Use the admin simulation command to avoid waiting for a full cycle:
-
-```bash
-/pvpadmin simtime 3600
-```
-
-Then run `/pvp status` to confirm the player enters forced PvP when a cycle threshold is crossed.
+Run `/pvpadmin player <name> setdebt <seconds>` to give a player debt, then run `/pvp status` to confirm the player is in forced PvP.
 
 ## Next Steps
 

--- a/src/main/java/org/SSoggy/SSoggyPvP/command/PvPAdminCommand.java
+++ b/src/main/java/org/SSoggy/SSoggyPvP/command/PvPAdminCommand.java
@@ -49,7 +49,6 @@ public class PvPAdminCommand implements TabExecutor {
             case "zone"     -> handleZone(sender, args);
             case SUB_PLAYER -> handlePlayer(sender, args);
             case "reload"   -> handleReload(sender);
-            case "simtime"  -> handleSimtime(sender, args);
             default         -> { return false; }
         }
         return true;
@@ -198,27 +197,6 @@ public class PvPAdminCommand implements TabExecutor {
         }
     }
 
-    // temp test command - adds fake playtime so you don't have to wait an hour
-    private void handleSimtime(CommandSender sender, String[] args) {
-        Player player = CommandUtil.requirePlayer(sender, PLAYERS_ONLY);
-        if (player == null) return;
-        if (args.length < 2) {
-            MessageUtil.send(sender, "&cUsage: /pvpadmin simtime <seconds>");
-            return;
-        }
-        try {
-            long seconds = Long.parseLong(args[1]);
-            PlayerData data = plugin.getPvPManager().getPlayerData(player.getUniqueId());
-            data.setTotalPlaytimeSeconds(data.getTotalPlaytimeSeconds() + seconds);
-            MessageUtil.send(player, "&aAdded &f" + MessageUtil.formatTime(seconds)
-                    + " &ato your playtime. Total: &f"
-                    + MessageUtil.formatTime(data.getTotalPlaytimeSeconds()));
-            MessageUtil.send(player, "&7(Debt will trigger on the next tick if a cycle threshold is crossed)");
-        } catch (NumberFormatException e) {
-            MessageUtil.send(sender, "&cInvalid number: &f" + args[1]);
-        }
-    }
-
     private void handleReload(CommandSender sender) {
         plugin.reloadPluginConfig();
         MessageUtil.send(sender, "&aConfiguration reloaded!");
@@ -235,7 +213,6 @@ public class PvPAdminCommand implements TabExecutor {
         MessageUtil.send(sender, "&e/pvpadmin player <name> reset &7— reset player data");
         MessageUtil.send(sender, "&e/pvpadmin player <name> setdebt <sec> &7— set PvP debt");
         MessageUtil.send(sender, "&e/pvpadmin reload &7— reload config");
-        MessageUtil.send(sender, "&e/pvpadmin simtime <seconds> &7— add fake playtime (testing)");
     }
 
     @Override
@@ -243,7 +220,7 @@ public class PvPAdminCommand implements TabExecutor {
         List<String> completions = new ArrayList<>();
 
         switch (args.length) {
-            case 1 -> completions.addAll(Arrays.asList("wand", "zone", SUB_PLAYER, "reload", "simtime"));
+            case 1 -> completions.addAll(Arrays.asList("wand", "zone", SUB_PLAYER, "reload"));
             case 2 -> {
                 if (args[0].equalsIgnoreCase("zone")) {
                     completions.addAll(Arrays.asList("create", SUB_DELETE, "list", "info"));


### PR DESCRIPTION
🎯 **What:** Removed the temporary `/pvpadmin simtime` test command and all its references from the codebase and documentation.
💡 **Why:** The comment indicated this was a "temp test command", and removing it cleans up the codebase for production use, improving maintainability.
✅ **Verification:** Verified compilation and tests pass using `mvn test`. Checked that all references to the command in code and markdown files were successfully removed.
✨ **Result:** Improved code health and documentation accuracy by removing dead test code.

---
*PR created automatically by Jules for task [2927746801107990530](https://jules.google.com/task/2927746801107990530) started by @SSoggyTacoMan*