### PR TITLE
⚡ Optimize Debug Logging by Caching Config Lookup

### DIFF
--- a/src/main/java/org/SSoggy/SSoggyPvP/PvPTogglePlugin.java
+++ b/src/main/java/org/SSoggy/SSoggyPvP/PvPTogglePlugin.java
@@ -86,9 +86,10 @@ public class PvPTogglePlugin extends JavaPlugin {
         reloadConfig();
         
         // reload cached config values in managers and listeners
+        if (pvpManager != null)      pvpManager.loadConfigValues();
         if (playtimeManager != null) playtimeManager.loadConfigValues();
-        if (zoneManager != null) zoneManager.loadZones();
-        if (combatListener != null) combatListener.loadConfig();
+        if (zoneManager != null)     zoneManager.loadZones();
+        if (combatListener != null)  combatListener.loadConfig();
         if (zoneListener != null)    zoneListener.loadConfig();
     }
 

--- a/src/main/java/org/SSoggy/SSoggyPvP/manager/PvPManager.java
+++ b/src/main/java/org/SSoggy/SSoggyPvP/manager/PvPManager.java
@@ -19,7 +19,7 @@ public class PvPManager {
 
     private final PvPTogglePlugin plugin;
     private final Map<UUID, PlayerData> playerDataMap = new ConcurrentHashMap<>();
-    private boolean debugEnabled;
+    private volatile boolean debugEnabled;
 
     // sync writes to the player data file
     private final Object saveLock = new Object();

--- a/src/main/java/org/SSoggy/SSoggyPvP/manager/PvPManager.java
+++ b/src/main/java/org/SSoggy/SSoggyPvP/manager/PvPManager.java
@@ -19,12 +19,18 @@ public class PvPManager {
 
     private final PvPTogglePlugin plugin;
     private final Map<UUID, PlayerData> playerDataMap = new ConcurrentHashMap<>();
-    
+    private boolean debugEnabled;
+
     // sync writes to the player data file
     private final Object saveLock = new Object();
 
     public PvPManager(PvPTogglePlugin plugin) {
         this.plugin = plugin;
+        loadConfigValues();
+    }
+
+    public void loadConfigValues() {
+        this.debugEnabled = plugin.getConfig().getBoolean("debug", false);
     }
 
     // grab or make player data
@@ -55,7 +61,7 @@ public class PvPManager {
         boolean inZone = plugin.getZoneManager().isInForcedPvPZone(player.getLocation());
         boolean hasDebt = data.getPvpDebtSeconds() > 0 && !player.hasPermission("pvptoggle.bypass");
 
-        DebugUtil.logDebug(plugin.getConfig(), plugin.getLogger(),
+        DebugUtil.logDebug(debugEnabled, plugin.getLogger(),
                 "PvP check for {0}: toggle={1}, inZone={2}, hasDebt={3}",
                 player.getName(), toggle, inZone, hasDebt);
 

--- a/src/main/java/org/SSoggy/SSoggyPvP/util/DebugUtil.java
+++ b/src/main/java/org/SSoggy/SSoggyPvP/util/DebugUtil.java
@@ -3,14 +3,12 @@ package org.SSoggy.SSoggyPvP.util;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import org.bukkit.configuration.file.FileConfiguration;
-
 public final class DebugUtil {
 
     private DebugUtil() {}
 
-    public static void logDebug(FileConfiguration config, Logger logger, String message, Object... params) {
-        if (config.getBoolean("debug", false)) {
+    public static void logDebug(boolean debugEnabled, Logger logger, String message, Object... params) {
+        if (debugEnabled) {
             logger.log(Level.INFO, "[DEBUG] " + message, params);
         }
     }


### PR DESCRIPTION
💡 **What:** Cached the `debug` configuration value in `PvPManager` and updated `DebugUtil.logDebug` to accept a `boolean` instead of `FileConfiguration`.
🎯 **Why:** `FileConfiguration.getBoolean()` performs a YAML lookup which involves tree traversal. This was being called in `isEffectivePvPEnabled`, which is a hot path during combat (called every time a player is damaged). Caching this value removes this overhead.
📊 **Measured Improvement:** An empirical benchmark was impractical due to the restricted environment (no network for Maven plugins). However, caching a primitive boolean is significantly more efficient than traversing a `FileConfiguration` tree and performing string lookups for the "debug" key on every combat event.

---
*PR created automatically by Jules for task [4976309564638829031](https://jules.google.com/task/4976309564638829031) started by @SSoggyTacoMan*