### PR TITLE
🔒 Prevent Path Traversal in YamlUtil

### DIFF
--- a/src/main/java/org/SSoggy/SSoggyPvP/util/YamlUtil.java
+++ b/src/main/java/org/SSoggy/SSoggyPvP/util/YamlUtil.java
@@ -26,12 +26,11 @@ public final class YamlUtil {
     }
 
     public static ConfigurationSection loadSection(File dataFolder, String filename, String sectionKey) {
-        if (!isSafePath(dataFolder, filename)) {
+        File file = getSafeFile(dataFolder, filename);
+        if (file == null) {
             LOGGER.log(Level.WARNING, "Blocked potential path traversal attempt: {0}", filename);
             return null;
         }
-
-        File file = new File(dataFolder, filename);
         if (!file.exists()) {
             // file doesn't exist - expected on first run
             return null;

--- a/src/main/java/org/SSoggy/SSoggyPvP/util/YamlUtil.java
+++ b/src/main/java/org/SSoggy/SSoggyPvP/util/YamlUtil.java
@@ -2,6 +2,7 @@ package org.SSoggy.SSoggyPvP.util;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -14,7 +15,22 @@ public final class YamlUtil {
 
     private YamlUtil() {}
 
+    private static boolean isSafePath(File dataFolder, String filename) {
+        try {
+            File file = new File(dataFolder, filename).getCanonicalFile();
+            File folder = dataFolder.getCanonicalFile();
+            return file.toPath().startsWith(folder.toPath());
+        } catch (IOException e) {
+            return false;
+        }
+    }
+
     public static ConfigurationSection loadSection(File dataFolder, String filename, String sectionKey) {
+        if (!isSafePath(dataFolder, filename)) {
+            LOGGER.log(Level.WARNING, "Blocked potential path traversal attempt: {0}", filename);
+            return null;
+        }
+
         File file = new File(dataFolder, filename);
         if (!file.exists()) {
             // file doesn't exist - expected on first run
@@ -38,6 +54,11 @@ public final class YamlUtil {
 
     public static void saveConfig(YamlConfiguration config, File dataFolder, String filename, 
                                    Logger logger, String errorMessage) {
+        if (!isSafePath(dataFolder, filename)) {
+            logger.log(Level.WARNING, "Blocked potential path traversal attempt while saving: {0}", filename);
+            return;
+        }
+
         try {
             config.save(new File(dataFolder, filename));
         } catch (IOException e) {

--- a/src/main/java/org/SSoggy/SSoggyPvP/util/YamlUtil.java
+++ b/src/main/java/org/SSoggy/SSoggyPvP/util/YamlUtil.java
@@ -15,14 +15,18 @@ public final class YamlUtil {
 
     private YamlUtil() {}
 
-    private static boolean isSafePath(File dataFolder, String filename) {
+    private static File getSafeFile(File dataFolder, String filename) {
+        if (dataFolder == null || filename == null) return null;
         try {
             File file = new File(dataFolder, filename).getCanonicalFile();
             File folder = dataFolder.getCanonicalFile();
-            return file.toPath().startsWith(folder.toPath());
-        } catch (IOException e) {
-            return false;
+            if (file.toPath().startsWith(folder.toPath())) {
+                return file;
+            }
+        } catch (IOException | RuntimeException e) {
+            return null;
         }
+        return null;
     }
 
     public static ConfigurationSection loadSection(File dataFolder, String filename, String sectionKey) {
@@ -31,6 +35,7 @@ public final class YamlUtil {
             LOGGER.log(Level.WARNING, "Blocked potential path traversal attempt: {0}", filename);
             return null;
         }
+
         if (!file.exists()) {
             // file doesn't exist - expected on first run
             return null;
@@ -53,13 +58,14 @@ public final class YamlUtil {
 
     public static void saveConfig(YamlConfiguration config, File dataFolder, String filename, 
                                    Logger logger, String errorMessage) {
-        if (!isSafePath(dataFolder, filename)) {
+        File file = getSafeFile(dataFolder, filename);
+        if (file == null) {
             logger.log(Level.WARNING, "Blocked potential path traversal attempt while saving: {0}", filename);
             return;
         }
 
         try {
-            config.save(new File(dataFolder, filename));
+            config.save(file);
         } catch (IOException e) {
             logger.log(Level.SEVERE, errorMessage, e);
         }


### PR DESCRIPTION
🎯 **What:** Fixed a potential path traversal vulnerability in `YamlUtil.java`.
⚠️ **Risk:** If a future feature allowed user-supplied filenames, an attacker could read or overwrite arbitrary YAML files on the server by using `../` in the filename.
🛡️ **Solution:** Implemented `isSafePath` helper that uses `getCanonicalFile()` and `Path.startsWith()` to verify that the target file is contained within the intended data folder. Validation is applied to both `loadSection` and `saveConfig` methods.

---
*PR created automatically by Jules for task [6147562922065049237](https://jules.google.com/task/6147562922065049237) started by @SSoggyTacoMan*