### PR TITLE
Feat: Add customization options to playtime debt system

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,11 +82,11 @@ The playtime debt system automatically enforces periods of mandatory PvP based o
 
 ### How It Works
 
-- Players accumulate playtime as they play on the server
-- After a configured number of hours (default: 1 hour), players enter a forced PvP period
+- Players accumulate playtime as they play on the server (by default, even when online alone; set `solo-accumulate: false` to require 2+ players)
+- After a configured number of minutes (default: 60 minutes via `minutes-per-cycle`), players enter a forced PvP period
 - During forced PvP, players cannot disable PvP
-- Forced PvP lasts for a configured duration (default: 20 minutes)
-- Debt only counts down when 2 or more players are online
+- Forced PvP lasts for a configured duration (default: 1200 seconds / 20 minutes)
+- By default, debt only counts down when 2 or more players are online; set `solo-forced: true` to also count down while alone
 - Logging out does not reduce debt
 
 ### Configuration
@@ -112,12 +112,12 @@ The plugin configuration is located at `plugins/SSoggyPvP-Manager/config.yml`.
 | Setting | Description | Default |
 |---------|-------------|---------|
 | `default-pvp-state` | Default PvP state for new players | `false` |
-| `playtime.minutes-per-cycle`| Minutes between forced PvP periods | `60` |
-| `playtime.hours-per-cycle`| Hours between forced PvP periods (Legacy) | `1` |
+| `playtime.minutes-per-cycle` | Minutes between forced PvP periods | `60` |
+| `playtime.hours-per-cycle` | Hours between forced PvP periods (Legacy) | `1` |
 | `playtime.forced-seconds` | Duration of forced PvP in seconds | `1200` |
 | `playtime.forced-minutes` | Duration of forced PvP in minutes (Legacy) | `20` |
-| `playtime.solo-accumulate`| Accumulate playtime when player is online alone | `true` |
-| `playtime.solo-forced`    | Decrease debt when player is online alone | `false` |
+| `playtime.solo-accumulate` | Accumulate playtime when player is online alone | `true` |
+| `playtime.solo-forced` | Decrease debt when player is online alone | `false` |
 | `zone-wand-material` | Material for zone selection wand | `BLAZE_ROD` |
 | `save-interval` | Auto-save interval in minutes | `5` |
 | `debug` | Enable debug logging | `false` |

--- a/README.md
+++ b/README.md
@@ -95,8 +95,12 @@ Configure the playtime system in `config.yml`:
 
 ```yaml
 playtime:
-  hours-per-cycle: 1        # Hours of playtime to trigger forced PvP
-  forced-minutes: 20        # Minutes of forced PvP per cycle
+  minutes-per-cycle: 60     # Minutes of playtime to trigger forced PvP (overrides hours-per-cycle)
+  hours-per-cycle: 1        # Legacy: Hours of playtime to trigger forced PvP
+  forced-seconds: 1200      # Seconds of forced PvP per cycle (overrides forced-minutes)
+  forced-minutes: 20        # Legacy: Minutes of forced PvP per cycle
+  solo-accumulate: true     # Whether playtime should accumulate when a player is online alone
+  solo-forced: false        # Whether forced PvP debt should decrease when a player is online alone
 ```
 
 ## Configuration
@@ -108,8 +112,12 @@ The plugin configuration is located at `plugins/SSoggyPvP-Manager/config.yml`.
 | Setting | Description | Default |
 |---------|-------------|---------|
 | `default-pvp-state` | Default PvP state for new players | `false` |
-| `playtime.hours-per-cycle` | Hours between forced PvP periods | `1` |
-| `playtime.forced-minutes` | Duration of forced PvP in minutes | `20` |
+| `playtime.minutes-per-cycle`| Minutes between forced PvP periods | `60` |
+| `playtime.hours-per-cycle`| Hours between forced PvP periods (Legacy) | `1` |
+| `playtime.forced-seconds` | Duration of forced PvP in seconds | `1200` |
+| `playtime.forced-minutes` | Duration of forced PvP in minutes (Legacy) | `20` |
+| `playtime.solo-accumulate`| Accumulate playtime when player is online alone | `true` |
+| `playtime.solo-forced`    | Decrease debt when player is online alone | `false` |
 | `zone-wand-material` | Material for zone selection wand | `BLAZE_ROD` |
 | `save-interval` | Auto-save interval in minutes | `5` |
 | `debug` | Enable debug logging | `false` |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -23,8 +23,12 @@ The config controls:
 default-pvp-state: false
 
 playtime:
+  minutes-per-cycle: 60
   hours-per-cycle: 1
+  forced-seconds: 1200
   forced-minutes: 20
+  solo-accumulate: true
+  solo-forced: false
 
 zone-wand-material: BLAZE_ROD
 
@@ -73,12 +77,20 @@ Useful format codes:
 
 ```yaml
 playtime:
+  minutes-per-cycle: 60
   hours-per-cycle: 1
+  forced-seconds: 1200
   forced-minutes: 20
+  solo-accumulate: true
+  solo-forced: false
 ```
 
-- `hours-per-cycle`: how much accumulated playtime triggers a forced PvP cycle
-- `forced-minutes`: how long forced PvP lasts for each processed cycle
+- `minutes-per-cycle`: how many minutes of accumulated playtime triggers a forced PvP cycle (overrides `hours-per-cycle`)
+- `hours-per-cycle`: legacy support; how many hours of playtime triggers a forced PvP cycle
+- `forced-seconds`: how many seconds forced PvP lasts for each processed cycle (overrides `forced-minutes`)
+- `forced-minutes`: legacy support; how many minutes forced PvP lasts for each processed cycle
+- `solo-accumulate`: whether playtime accumulates when a player is online alone
+- `solo-forced`: whether forced PvP debt counts down when a player is online alone
 
 See [Playtime System](playtime-system) for behavior details.
 

--- a/docs/playtime-system.md
+++ b/docs/playtime-system.md
@@ -25,7 +25,7 @@ With the default values:
 
 ## How It Works
 
-1. A player accumulates normal playtime while online (can be configured to only accumulate when 2+ players are online using `solo-accumulate`).
+1. A player accumulates normal playtime while online. By default this happens even when alone; set `solo-accumulate: false` to require 2+ players online before playtime counts.
 2. When their total playtime crosses a configured cycle threshold (`minutes-per-cycle` or `hours-per-cycle`), the plugin records a processed cycle.
 3. The player gains forced PvP debt for that cycle (`forced-seconds` or `forced-minutes`).
 4. While debt is active, PvP cannot be turned off.

--- a/docs/playtime-system.md
+++ b/docs/playtime-system.md
@@ -10,22 +10,26 @@ SSoggyPvP-Manager can force players into PvP after they accumulate a configured 
 
 ```yaml
 playtime:
+  minutes-per-cycle: 60
   hours-per-cycle: 1
+  forced-seconds: 1200
   forced-minutes: 20
+  solo-accumulate: true
+  solo-forced: false
 ```
 
 With the default values:
 
-- each 1 hour of playtime creates a cycle
-- each cycle adds 20 minutes of forced PvP debt
+- each 60 minutes of playtime creates a cycle
+- each cycle adds 1200 seconds (20 minutes) of forced PvP debt
 
 ## How It Works
 
-1. A player accumulates normal playtime while online.
-2. When their total playtime crosses a configured cycle threshold, the plugin records a processed cycle.
-3. The player gains forced PvP debt for that cycle.
+1. A player accumulates normal playtime while online (can be configured to only accumulate when 2+ players are online using `solo-accumulate`).
+2. When their total playtime crosses a configured cycle threshold (`minutes-per-cycle` or `hours-per-cycle`), the plugin records a processed cycle.
+3. The player gains forced PvP debt for that cycle (`forced-seconds` or `forced-minutes`).
 4. While debt is active, PvP cannot be turned off.
-5. Debt only counts down when at least 2 players are online.
+5. Debt counts down according to the `solo-forced` configuration (by default, only when at least 2 players are online).
 6. Logging out does not clear debt.
 
 ## Player Experience

--- a/src/main/java/org/SSoggy/SSoggyPvP/manager/PlaytimeManager.java
+++ b/src/main/java/org/SSoggy/SSoggyPvP/manager/PlaytimeManager.java
@@ -20,7 +20,9 @@ public class PlaytimeManager {
     
     // cached config values (updated on reload)
     private long cycleSeconds;
-    private int forcedMinutes;
+    private long forcedDebtSeconds;
+    private boolean soloAccumulate;
+    private boolean soloForced;
 
     public PlaytimeManager(PvPTogglePlugin plugin) {
         this.plugin = plugin;
@@ -28,16 +30,31 @@ public class PlaytimeManager {
     }
     
     public void loadConfigValues() {
-        int hoursPerCycle = plugin.getConfig().getInt("playtime.hours-per-cycle", 1);
-        
-        // validate hours-per-cycle to prevent division by zero
-        if (hoursPerCycle < 1) {
-            plugin.getLogger().log(Level.WARNING, "[PvPToggle] Invalid value for ''playtime.hours-per-cycle'' ({0}); using 1 instead.", hoursPerCycle);
-            hoursPerCycle = 1;
+        // Fallback hierarchy for backwards compatibility: minutes-per-cycle -> hours-per-cycle -> 1 hour
+        int minutesPerCycle = plugin.getConfig().getInt("playtime.minutes-per-cycle", -1);
+        if (minutesPerCycle == -1) {
+            int hoursPerCycle = plugin.getConfig().getInt("playtime.hours-per-cycle", 1);
+            if (hoursPerCycle < 1) {
+                plugin.getLogger().log(Level.WARNING, "[PvPToggle] Invalid value for ''playtime.hours-per-cycle'' ({0}); using 1 instead.", hoursPerCycle);
+                hoursPerCycle = 1;
+            }
+            minutesPerCycle = hoursPerCycle * 60;
+        } else if (minutesPerCycle < 1) {
+            plugin.getLogger().log(Level.WARNING, "[PvPToggle] Invalid value for ''playtime.minutes-per-cycle'' ({0}); using 60 instead.", minutesPerCycle);
+            minutesPerCycle = 60;
         }
-        
-        this.cycleSeconds = hoursPerCycle * 3600L;
-        this.forcedMinutes = plugin.getConfig().getInt("playtime.forced-minutes", 20);
+        this.cycleSeconds = minutesPerCycle * 60L;
+
+        // Fallback hierarchy for forced time: forced-seconds -> forced-minutes -> 20 minutes
+        int forcedSeconds = plugin.getConfig().getInt("playtime.forced-seconds", -1);
+        if (forcedSeconds == -1) {
+            int forcedMinutes = plugin.getConfig().getInt("playtime.forced-minutes", 20);
+            forcedSeconds = forcedMinutes * 60;
+        }
+        this.forcedDebtSeconds = forcedSeconds;
+
+        this.soloAccumulate = plugin.getConfig().getBoolean("playtime.solo-accumulate", true);
+        this.soloForced = plugin.getConfig().getBoolean("playtime.solo-forced", false);
     }
 
     public void startTracking() {
@@ -82,7 +99,11 @@ public class PlaytimeManager {
 
         for (Player player : Bukkit.getOnlinePlayers()) {
             PlayerData data = plugin.getPvPManager().getPlayerData(player.getUniqueId());
-            data.setTotalPlaytimeSeconds(data.getTotalPlaytimeSeconds() + 1);
+
+            if (soloAccumulate || onlinePlayerCount >= 2) {
+                data.setTotalPlaytimeSeconds(data.getTotalPlaytimeSeconds() + 1);
+            }
+
             checkAndApplyCycleMilestones(player, data);
             decrementPlayerDebt(player, data, onlinePlayerCount);
         }
@@ -96,18 +117,28 @@ public class PlaytimeManager {
         data.setProcessedCycles(currentCycles);
 
         if (!player.hasPermission("pvptoggle.bypass")) {
-            long additionalDebt = newCycles * forcedMinutes * 60L;
+            long additionalDebt = newCycles * forcedDebtSeconds;
+            boolean alreadyInDebt = data.getPvpDebtSeconds() > 0;
             data.setPvpDebtSeconds(data.getPvpDebtSeconds() + additionalDebt);
-            MessageUtil.send(player,
-                    "&c&l⚔ Forced PvP activated! &7Duration: &f"
-                            + MessageUtil.formatTime(data.getPvpDebtSeconds()));
+
+            if (alreadyInDebt) {
+                MessageUtil.send(player,
+                        "&c&l⚔ Forced PvP extended! &7Duration: &f"
+                                + MessageUtil.formatTime(data.getPvpDebtSeconds()));
+            } else {
+                MessageUtil.send(player,
+                        "&c&l⚔ Forced PvP activated! &7Duration: &f"
+                                + MessageUtil.formatTime(data.getPvpDebtSeconds()));
+            }
         }
     }
 
     private void decrementPlayerDebt(Player player, PlayerData data, int onlinePlayerCount) {
         if (data.getPvpDebtSeconds() <= 0 || player.hasPermission("pvptoggle.bypass")) return;
 
-        if (onlinePlayerCount >= 2) {
+        boolean isDecreasing = soloForced || onlinePlayerCount >= 2;
+
+        if (isDecreasing) {
             data.setPvpDebtSeconds(data.getPvpDebtSeconds() - 1);
         }
 
@@ -117,7 +148,7 @@ public class PlaytimeManager {
             MessageUtil.sendActionBar(player, "&a✓ Forced PvP ended");
         } else {
             // action bar shown once per second (task runs every 20 ticks / 1 second)
-            String status = (onlinePlayerCount >= 2)
+            String status = isDecreasing
                     ? "&c⚔ Forced PvP"
                     : "&e⚔ Forced PvP &7(paused — solo)";
             MessageUtil.sendActionBar(player,

--- a/src/main/java/org/SSoggy/SSoggyPvP/manager/PlaytimeManager.java
+++ b/src/main/java/org/SSoggy/SSoggyPvP/manager/PlaytimeManager.java
@@ -31,27 +31,36 @@ public class PlaytimeManager {
     
     public void loadConfigValues() {
         // Fallback hierarchy for backwards compatibility: minutes-per-cycle -> hours-per-cycle -> 1 hour
-        int minutesPerCycle = plugin.getConfig().getInt("playtime.minutes-per-cycle", -1);
-        if (minutesPerCycle == -1) {
+        int minutesPerCycleConfig = plugin.getConfig().getInt("playtime.minutes-per-cycle", -1);
+        if (minutesPerCycleConfig == -1) {
             int hoursPerCycle = plugin.getConfig().getInt("playtime.hours-per-cycle", 1);
             if (hoursPerCycle < 1) {
                 plugin.getLogger().log(Level.WARNING, "[PvPToggle] Invalid value for ''playtime.hours-per-cycle'' ({0}); using 1 instead.", hoursPerCycle);
                 hoursPerCycle = 1;
             }
-            minutesPerCycle = hoursPerCycle * 60;
-        } else if (minutesPerCycle < 1) {
-            plugin.getLogger().log(Level.WARNING, "[PvPToggle] Invalid value for ''playtime.minutes-per-cycle'' ({0}); using 60 instead.", minutesPerCycle);
-            minutesPerCycle = 60;
+            this.cycleSeconds = (long) hoursPerCycle * 60 * 60;
+        } else if (minutesPerCycleConfig < 1) {
+            plugin.getLogger().log(Level.WARNING, "[PvPToggle] Invalid value for ''playtime.minutes-per-cycle'' ({0}); using 60 instead.", minutesPerCycleConfig);
+            this.cycleSeconds = 60L * 60;
+        } else {
+            this.cycleSeconds = (long) minutesPerCycleConfig * 60;
         }
-        this.cycleSeconds = minutesPerCycle * 60L;
 
         // Fallback hierarchy for forced time: forced-seconds -> forced-minutes -> 20 minutes
-        int forcedSeconds = plugin.getConfig().getInt("playtime.forced-seconds", -1);
-        if (forcedSeconds == -1) {
+        int forcedSecondsConfig = plugin.getConfig().getInt("playtime.forced-seconds", -1);
+        if (forcedSecondsConfig == -1) {
             int forcedMinutes = plugin.getConfig().getInt("playtime.forced-minutes", 20);
-            forcedSeconds = forcedMinutes * 60;
+            if (forcedMinutes < 0) {
+                plugin.getLogger().log(Level.WARNING, "[PvPToggle] Invalid value for ''playtime.forced-minutes'' ({0}); using 20 instead.", forcedMinutes);
+                forcedMinutes = 20;
+            }
+            this.forcedDebtSeconds = (long) forcedMinutes * 60;
+        } else if (forcedSecondsConfig < 0) {
+            plugin.getLogger().log(Level.WARNING, "[PvPToggle] Invalid value for ''playtime.forced-seconds'' ({0}); using 1200 instead.", forcedSecondsConfig);
+            this.forcedDebtSeconds = 1200L;
+        } else {
+            this.forcedDebtSeconds = forcedSecondsConfig;
         }
-        this.forcedDebtSeconds = forcedSeconds;
 
         this.soloAccumulate = plugin.getConfig().getBoolean("playtime.solo-accumulate", true);
         this.soloForced = plugin.getConfig().getBoolean("playtime.solo-forced", false);

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -19,10 +19,21 @@ messages:
 
 # Playtime settings
 playtime:
-  # How many hours of playtime trigger a forced PvP period
+  # Minutes of playtime to trigger forced PvP (overrides hours-per-cycle)
+  minutes-per-cycle: 60
+  # Legacy support: How many hours of playtime trigger a forced PvP period (used if minutes-per-cycle is not set)
   hours-per-cycle: 1
-  # How many minutes of forced PvP per cycle
+
+  # Seconds of forced PvP per cycle (overrides forced-minutes)
+  forced-seconds: 1200
+  # Legacy support: How many minutes of forced PvP per cycle (used if forced-seconds is not set)
   forced-minutes: 20
+
+  # Whether playtime should accumulate when a player is online alone
+  solo-accumulate: true
+
+  # Whether forced PvP debt should decrease when a player is online alone
+  solo-forced: false
 
 # Zone wand material (any valid Bukkit Material name)
 zone-wand-material: BLAZE_ROD


### PR DESCRIPTION
Added new customization options to the playtime debt system including `solo-accumulate` (accumulate playtime while alone), `solo-forced` (forced debt while alone), `minutes-per-cycle` (ratio over legacy hours), and `forced-seconds` (ratio over legacy minutes). Modified `PlaytimeManager.java` to apply logic while keeping backwards compatibility. Updated config and markdown documentation.

---
*PR created automatically by Jules for task [9792000181579968979](https://jules.google.com/task/9792000181579968979) started by @SSoggyTacoMan*