### PR TITLE
🧹 [code health improvement] Remove unnecessary empty switch default block

### DIFF
--- a/src/main/java/org/SSoggy/SSoggyPvP/command/PvPAdminCommand.java
+++ b/src/main/java/org/SSoggy/SSoggyPvP/command/PvPAdminCommand.java
@@ -264,7 +264,6 @@ public class PvPAdminCommand implements TabExecutor {
                     completions.addAll(Arrays.asList("info", "reset", "setdebt"));
                 }
             }
-            default -> { /* no completions */ }
         }
 
         String last = args[args.length - 1].toLowerCase();


### PR DESCRIPTION
### 🎯 What: The code health issue addressed
Removed an unnecessary empty `default` block in a `switch` statement within the `onTabComplete` method in `src/main/java/org/SSoggy/SSoggyPvP/command/PvPAdminCommand.java`.

### 💡 Why: How this improves maintainability
The `default` branch was empty and redundant because the switch operates on an integer (`args.length`) and is used as a statement, not an expression. Removing it reduces boilerplate and follows cleaner coding practices.

### ✅ Verification: How you confirmed the change is safe
- **Manual Inspection:** Verified that the removal of the optional `default` branch does not alter the logic of the tab completion.
- **Code Review:** The change was reviewed and rated as #Correct#.
- **Compilation Check:** Attempted compilation, noting that failures were due to the offline environment's missing dependencies rather than the code change itself.

### ✨ Result: The improvement achieved
Improved code readability and reduced unnecessary lines in the `PvPAdminCommand` class.

---
*PR created automatically by Jules for task [7391536079414348117](https://jules.google.com/task/7391536079414348117) started by @SSoggyTacoMan*