### PR TITLE
🧪 [testing] Add error handling tests for ConfigUtil.getWandMaterial

### DIFF
--- a/src/test/java/org/SSoggy/SSoggyPvP/util/ConfigUtilTest.java
+++ b/src/test/java/org/SSoggy/SSoggyPvP/util/ConfigUtilTest.java
@@ -1,0 +1,51 @@
+package org.SSoggy.SSoggyPvP.util;
+
+import org.bukkit.Material;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class ConfigUtilTest {
+
+    @Test
+    void testGetWandMaterial_ValidMaterial() {
+        FileConfiguration config = mock(FileConfiguration.class);
+        when(config.getString("zone-wand-material")).thenReturn("STICK");
+
+        Material material = ConfigUtil.getWandMaterial(config);
+
+        assertEquals(Material.STICK, material);
+    }
+
+    @Test
+    void testGetWandMaterial_InvalidMaterial() {
+        FileConfiguration config = mock(FileConfiguration.class);
+        when(config.getString("zone-wand-material")).thenReturn("INVALID_MAT");
+
+        Material material = ConfigUtil.getWandMaterial(config);
+
+        assertEquals(Material.BLAZE_ROD, material);
+    }
+
+    @Test
+    void testGetWandMaterial_NullMaterial() {
+        FileConfiguration config = mock(FileConfiguration.class);
+        when(config.getString("zone-wand-material")).thenReturn(null);
+
+        Material material = ConfigUtil.getWandMaterial(config);
+
+        assertEquals(Material.BLAZE_ROD, material);
+    }
+
+    @Test
+    void testGetWandMaterial_LowerCaseMaterial() {
+        FileConfiguration config = mock(FileConfiguration.class);
+        when(config.getString("zone-wand-material")).thenReturn("stick");
+
+        Material material = ConfigUtil.getWandMaterial(config);
+
+        assertEquals(Material.STICK, material);
+    }
+}


### PR DESCRIPTION
This PR introduces a new test class `ConfigUtilTest` to provide unit testing coverage for the `ConfigUtil.getWandMaterial` method.

The following scenarios are now covered:
- **Valid Material**: Ensures that a valid material string (e.g., "STICK") returns the correct Bukkit `Material`.
- **Invalid Material**: Verifies that the method gracefully handles invalid material names by catching `IllegalArgumentException` and falling back to the default `BLAZE_ROD`.
- **Null Configuration**: Confirms that missing configuration keys also result in the default `BLAZE_ROD`.
- **Case Insensitivity**: Validates that material names are correctly processed regardless of case.

These tests ensure that the plugin's configuration loading logic remains robust even when provided with incorrect or missing input.

---
*PR created automatically by Jules for task [938441929375428920](https://jules.google.com/task/938441929375428920) started by @SSoggyTacoMan*