### PR TITLE
🧪 Add test for PlayerData setPvpDebtSeconds edge case

### DIFF
--- a/src/test/java/org/SSoggy/SSoggyPvP/model/PlayerDataTest.java
+++ b/src/test/java/org/SSoggy/SSoggyPvP/model/PlayerDataTest.java
@@ -1,0 +1,28 @@
+package org.SSoggy.SSoggyPvP.model;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class PlayerDataTest {
+
+    @Test
+    void testSetPvpDebtSecondsNegative() {
+        PlayerData data = new PlayerData();
+        data.setPvpDebtSeconds(-5L);
+        assertEquals(0L, data.getPvpDebtSeconds(), "Setting a negative debt should result in 0");
+    }
+
+    @Test
+    void testSetPvpDebtSecondsZero() {
+        PlayerData data = new PlayerData();
+        data.setPvpDebtSeconds(0L);
+        assertEquals(0L, data.getPvpDebtSeconds(), "Setting 0 debt should result in 0");
+    }
+
+    @Test
+    void testSetPvpDebtSecondsPositive() {
+        PlayerData data = new PlayerData();
+        data.setPvpDebtSeconds(100L);
+        assertEquals(100L, data.getPvpDebtSeconds(), "Setting a positive debt should result in the same value");
+    }
+}


### PR DESCRIPTION
🎯 What: Added tests to verify `PlayerData.setPvpDebtSeconds` behaves correctly with negative, zero, and positive inputs.
📊 Coverage: Tested the scenarios where debt is set to negative (asserting it snaps to 0), zero, and positive values.
✨ Result: Improved coverage for `PlayerData` model and guarded against negative debt logic errors.

---
*PR created automatically by Jules for task [18418866225332375594](https://jules.google.com/task/18418866225332375594) started by @SSoggyTacoMan*