### PR TITLE
🧪 Add tests for PlayerData model

### DIFF
--- a/src/test/java/org/SSoggy/SSoggyPvP/model/PlayerDataTest.java
+++ b/src/test/java/org/SSoggy/SSoggyPvP/model/PlayerDataTest.java
@@ -1,0 +1,69 @@
+package org.SSoggy.SSoggyPvP.model;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PlayerDataTest {
+
+    private PlayerData playerData;
+
+    @BeforeEach
+    void setUp() {
+        playerData = new PlayerData();
+    }
+
+    @Test
+    void testDefaultConstructor() {
+        assertFalse(playerData.isPvpEnabled(), "PvP should be disabled by default");
+        assertEquals(0L, playerData.getTotalPlaytimeSeconds(), "Total playtime should be 0 by default");
+        assertEquals(0, playerData.getProcessedCycles(), "Processed cycles should be 0 by default");
+        assertEquals(0L, playerData.getPvpDebtSeconds(), "PvP debt should be 0 by default");
+    }
+
+    @Test
+    void testSetPvpEnabled() {
+        playerData.setPvpEnabled(true);
+        assertTrue(playerData.isPvpEnabled(), "PvP should be enabled");
+
+        playerData.setPvpEnabled(false);
+        assertFalse(playerData.isPvpEnabled(), "PvP should be disabled");
+    }
+
+    @Test
+    void testSetTotalPlaytimeSeconds() {
+        playerData.setTotalPlaytimeSeconds(3600L);
+        assertEquals(3600L, playerData.getTotalPlaytimeSeconds(), "Total playtime should be updated");
+
+        playerData.setTotalPlaytimeSeconds(0L);
+        assertEquals(0L, playerData.getTotalPlaytimeSeconds(), "Total playtime should be updated to 0");
+    }
+
+    @Test
+    void testSetProcessedCycles() {
+        playerData.setProcessedCycles(5);
+        assertEquals(5, playerData.getProcessedCycles(), "Processed cycles should be updated");
+
+        playerData.setProcessedCycles(0);
+        assertEquals(0, playerData.getProcessedCycles(), "Processed cycles should be updated to 0");
+    }
+
+    @Test
+    void testSetPvpDebtSecondsPositive() {
+        playerData.setPvpDebtSeconds(1800L);
+        assertEquals(1800L, playerData.getPvpDebtSeconds(), "PvP debt should be set to positive value");
+    }
+
+    @Test
+    void testSetPvpDebtSecondsZero() {
+        playerData.setPvpDebtSeconds(0L);
+        assertEquals(0L, playerData.getPvpDebtSeconds(), "PvP debt should be set to 0");
+    }
+
+    @Test
+    void testSetPvpDebtSecondsNegativeClampsToZero() {
+        playerData.setPvpDebtSeconds(-500L);
+        assertEquals(0L, playerData.getPvpDebtSeconds(), "PvP debt should be clamped to 0 when negative value is set");
+    }
+}


### PR DESCRIPTION
🎯 **What:** Created a new test suite for `PlayerData.java` to fill a missing testing gap for this core data model.
📊 **Coverage:** The tests comprehensively cover the default constructor state, getters and setters for `pvpEnabled`, `totalPlaytimeSeconds`, and `processedCycles`. It also specifically covers the bounds-checking logic within `setPvpDebtSeconds` which uses `Math.max(0, ...)` to ensure debt seconds never go below zero.
✨ **Result:** Test coverage for `PlayerData` is now 100%, ensuring that regressions to this core POJO and its clamping logic are prevented.

---
*PR created automatically by Jules for task [16699219130486587052](https://jules.google.com/task/16699219130486587052) started by @SSoggyTacoMan*