### PR TITLE
🧹 Narrow exception handling in path traversal check

### DIFF
--- a/src/main/java/org/SSoggy/SSoggyPvP/util/YamlUtil.java
+++ b/src/main/java/org/SSoggy/SSoggyPvP/util/YamlUtil.java
@@ -23,7 +23,7 @@ public final class YamlUtil {
             if (file.toPath().startsWith(folder.toPath())) {
                 return file;
             }
-        } catch (IOException | RuntimeException e) {
+        } catch (IOException e) {
             return null;
         }
         return null;


### PR DESCRIPTION
🎯 **What:** Removed `RuntimeException` from the catch block in `YamlUtil.getSafeFile`, limiting it to only `IOException`.

💡 **Why:** `getCanonicalFile` properly throws `IOException` on failure. Catching `RuntimeException` in this context is overly broad and an anti-pattern as it can silently swallow bugs like `NullPointerException`, making the codebase harder to maintain and debug.

✅ **Verification:** Verified that building the project with `mvn clean package` succeeds and that no existing tests break (`mvn clean test`).

✨ **Result:** A safer path traversal checking function that accurately suppresses known IO-related exceptions while allowing unexpected runtime errors to surface appropriately, improving the overall debuggability of the code.

---
*PR created automatically by Jules for task [10090895930810453508](https://jules.google.com/task/10090895930810453508) started by @SSoggyTacoMan*