### PR TITLE
🧪 [testing] Add unit tests for CommandUtil

### DIFF
--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,5 @@
+🧪 [testing] Add unit tests for CommandUtil
+
+🎯 **What:** Added missing unit test coverage for `CommandUtil.java`, specifically testing the `requirePlayer` method.
+📊 **Coverage:** Covered both successful execution when a `Player` sender is passed and failure scenarios (returning `null` and sending color-translated error messages) when a non-Player `CommandSender` is passed.
+✨ **Result:** Increased codebase reliability by ensuring the core utility method `requirePlayer` handles different implementations of Bukkit's `CommandSender` correctly as expected without regressions.

--- a/src/test/java/org/SSoggy/SSoggyPvP/util/CommandUtilTest.java
+++ b/src/test/java/org/SSoggy/SSoggyPvP/util/CommandUtilTest.java
@@ -1,0 +1,35 @@
+package org.SSoggy.SSoggyPvP.util;
+
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class CommandUtilTest {
+
+    @Test
+    void testRequirePlayer_Success() {
+        Player mockPlayer = mock(Player.class);
+        String errorMessage = "You must be a player.";
+
+        Player result = CommandUtil.requirePlayer(mockPlayer, errorMessage);
+
+        assertSame(mockPlayer, result, "Should return the same player object");
+        verify(mockPlayer, never()).sendMessage(anyString());
+    }
+
+    @Test
+    void testRequirePlayer_Failure() {
+        CommandSender mockSender = mock(CommandSender.class);
+        String errorMessage = "&cYou must be a player.";
+
+        Player result = CommandUtil.requirePlayer(mockSender, errorMessage);
+
+        assertNull(result, "Should return null for non-player sender");
+        // MessageUtil uses ChatColor.translateAlternateColorCodes('&', message)
+        // § is the character used for colors in Bukkit
+        verify(mockSender).sendMessage("§cYou must be a player.");
+    }
+}


### PR DESCRIPTION
🎯 **What:** Added missing unit test coverage for `CommandUtil.java`, specifically testing the `requirePlayer` method.
📊 **Coverage:** Covered both successful execution when a `Player` sender is passed and failure scenarios (returning `null` and sending color-translated error messages) when a non-Player `CommandSender` is passed.
✨ **Result:** Increased codebase reliability by ensuring the core utility method `requirePlayer` handles different implementations of Bukkit's `CommandSender` correctly as expected without regressions.

---
*PR created automatically by Jules for task [3241111098506469794](https://jules.google.com/task/3241111098506469794) started by @SSoggyTacoMan*