### PR TITLE
🧪 Add unit tests for MessageUtil.send method

### DIFF
--- a/src/test/java/org/SSoggy/SSoggyPvP/util/MessageUtilTest.java
+++ b/src/test/java/org/SSoggy/SSoggyPvP/util/MessageUtilTest.java
@@ -1,0 +1,75 @@
+package org.SSoggy.SSoggyPvP.util;
+
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import net.md_5.bungee.api.ChatMessageType;
+import net.md_5.bungee.api.chat.TextComponent;
+import org.bukkit.ChatColor;
+
+class MessageUtilTest {
+
+    @Test
+    void testSendValidMessage() {
+        CommandSender sender = mock(CommandSender.class);
+        MessageUtil.send(sender, "&aHello World");
+        verify(sender).sendMessage("§aHello World");
+    }
+
+    @Test
+    void testSendNullMessage() {
+        CommandSender sender = mock(CommandSender.class);
+        MessageUtil.send(sender, null);
+        verifyNoInteractions(sender);
+    }
+
+    @Test
+    void testSendEmptyMessage() {
+        CommandSender sender = mock(CommandSender.class);
+        MessageUtil.send(sender, "");
+        verifyNoInteractions(sender);
+    }
+
+    @Test
+    void testSendActionBarValidMessage() {
+        Player player = mock(Player.class);
+        Player.Spigot spigot = mock(Player.Spigot.class);
+        when(player.spigot()).thenReturn(spigot);
+
+        MessageUtil.sendActionBar(player, "&aHello Action Bar");
+
+        verify(spigot).sendMessage(eq(ChatMessageType.ACTION_BAR), any(TextComponent.class));
+    }
+
+    @Test
+    void testSendActionBarNullMessage() {
+        Player player = mock(Player.class);
+        MessageUtil.sendActionBar(player, null);
+        verifyNoInteractions(player);
+    }
+
+    @Test
+    void testSendActionBarEmptyMessage() {
+        Player player = mock(Player.class);
+        MessageUtil.sendActionBar(player, "");
+        verifyNoInteractions(player);
+    }
+
+    @Test
+    void testFormatTime() {
+        assertEquals("0s", MessageUtil.formatTime(0));
+        assertEquals("0s", MessageUtil.formatTime(-5));
+        assertEquals("5s", MessageUtil.formatTime(5));
+        assertEquals("1m 0s", MessageUtil.formatTime(60));
+        assertEquals("1m 5s", MessageUtil.formatTime(65));
+        assertEquals("1h 0s", MessageUtil.formatTime(3600));
+        assertEquals("1h 1m 5s", MessageUtil.formatTime(3665));
+        assertEquals("2h 0s", MessageUtil.formatTime(7200));
+        assertEquals("2h 15m 30s", MessageUtil.formatTime(8130));
+    }
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
This PR adds the missing unit tests for the `MessageUtil.send` method. Because the class relies heavily on the static translation of alternative color codes and interactions with specific Bukkit objects, the class was missing dedicated, encapsulated testing. 

📊 **Coverage:** What scenarios are now tested
1. **Valid strings**: Verifies strings translate using Bukkit's `ChatColor`.
2. **Null handling**: Ensures sending a `null` string does not crash and avoids method calls to the `CommandSender`.
3. **Empty string handling**: Avoids processing and avoids empty line breaks for empty strings.
4. Additional coverage provided for: `sendActionBar` and `formatTime` methods. 

✨ **Result:** The improvement in test coverage
The `MessageUtilTest` class now fully covers the 3 core operations of the `MessageUtil` class. The tests verify outputs exactly and ensure stability by relying on `Mockito` rather than setting up a full Bukkit environment, significantly enhancing code quality and regressions checking.

---
*PR created automatically by Jules for task [8545551695056660324](https://jules.google.com/task/8545551695056660324) started by @SSoggyTacoMan*