### PR TITLE
🧪 [Testing Improvement] Add unit tests for PvPManager.getPlayerData

### DIFF
--- a/src/test/java/org/SSoggy/SSoggyPvP/manager/PvPManagerTest.java
+++ b/src/test/java/org/SSoggy/SSoggyPvP/manager/PvPManagerTest.java
@@ -1,0 +1,81 @@
+package org.SSoggy.SSoggyPvP.manager;
+
+import java.util.UUID;
+
+import org.bukkit.configuration.file.FileConfiguration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.SSoggy.SSoggyPvP.PvPTogglePlugin;
+import org.SSoggy.SSoggyPvP.model.PlayerData;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class PvPManagerTest {
+
+    private PvPTogglePlugin pluginMock;
+    private FileConfiguration configMock;
+    private PvPManager pvpManager;
+
+    @BeforeEach
+    void setUp() {
+        pluginMock = mock(PvPTogglePlugin.class);
+        configMock = mock(FileConfiguration.class);
+
+        when(pluginMock.getConfig()).thenReturn(configMock);
+        when(configMock.getBoolean("debug", false)).thenReturn(false);
+
+        pvpManager = new PvPManager(pluginMock);
+    }
+
+    @Test
+    void testGetPlayerData_NewPlayer_DefaultPvPTrue() {
+        UUID playerUuid = UUID.randomUUID();
+        when(configMock.getBoolean("default-pvp-state", false)).thenReturn(true);
+
+        PlayerData data = pvpManager.getPlayerData(playerUuid);
+
+        assertNotNull(data);
+        assertTrue(data.isPvpEnabled());
+
+        // Verify it was called
+        verify(configMock).getBoolean("default-pvp-state", false);
+    }
+
+    @Test
+    void testGetPlayerData_NewPlayer_DefaultPvPFalse() {
+        UUID playerUuid = UUID.randomUUID();
+        when(configMock.getBoolean("default-pvp-state", false)).thenReturn(false);
+
+        PlayerData data = pvpManager.getPlayerData(playerUuid);
+
+        assertNotNull(data);
+        assertFalse(data.isPvpEnabled());
+
+        // Verify it was called
+        verify(configMock).getBoolean("default-pvp-state", false);
+    }
+
+    @Test
+    void testGetPlayerData_ExistingPlayer() {
+        UUID playerUuid = UUID.randomUUID();
+        when(configMock.getBoolean("default-pvp-state", false)).thenReturn(true);
+
+        // First call creates the data
+        PlayerData data1 = pvpManager.getPlayerData(playerUuid);
+        assertNotNull(data1);
+        assertTrue(data1.isPvpEnabled());
+
+        // Change config mock just to be sure it's not checked again
+        when(configMock.getBoolean("default-pvp-state", false)).thenReturn(false);
+
+        // Second call should return the exact same object from the map
+        PlayerData data2 = pvpManager.getPlayerData(playerUuid);
+        assertSame(data1, data2);
+        assertTrue(data2.isPvpEnabled());
+
+        // Verify config was checked exactly once for default-pvp-state
+        verify(configMock, times(1)).getBoolean("default-pvp-state", false);
+    }
+}


### PR DESCRIPTION
🎯 **What:** 
Added unit tests for the `PvPManager.getPlayerData` method in `src/main/java/org/SSoggy/SSoggyPvP/manager/PvPManager.java`. The `getPlayerData` logic uses a `ConcurrentHashMap.computeIfAbsent` block to initialize new `PlayerData` based on the `default-pvp-state` from the plugin configuration.

📊 **Coverage:** 
- `testGetPlayerData_NewPlayer_DefaultPvPTrue`: Verifies that a new player's data is initialized with PvP enabled when the configuration `default-pvp-state` is true.
- `testGetPlayerData_NewPlayer_DefaultPvPFalse`: Verifies that a new player's data is initialized with PvP disabled when the configuration `default-pvp-state` is false.
- `testGetPlayerData_ExistingPlayer`: Verifies that the method returns the cached `PlayerData` object for existing players, rather than creating a new instance or fetching the `default-pvp-state` again.

✨ **Result:** 
The initialization and caching behavior of `getPlayerData` are now fully covered by tests, improving the reliability of the `PvPManager` and preventing regressions in player data retrieval.

---
*PR created automatically by Jules for task [14304128176802683476](https://jules.google.com/task/14304128176802683476) started by @SSoggyTacoMan*