### PR TITLE
🧪 [test] Add missing tests for ZoneManager.isInForcedPvPZone

### DIFF
--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,0 +1,14 @@
+🎯 **What:**
+Added unit tests for the `isInForcedPvPZone` method in `ZoneManager.java`. This method determines if a given location is inside any of the configured PvP zones, but it lacked dedicated tests to ensure its logic correctly checked null inputs, empty zones, inside/outside location logic, and cross-world interactions.
+
+📊 **Coverage:**
+We added the following test scenarios:
+- `testIsInForcedPvPZone_NullLocation`: Verifies it returns false for a null Location.
+- `testIsInForcedPvPZone_NullWorld`: Verifies it returns false for a Location with a null World.
+- `testIsInForcedPvPZone_EmptyZones`: Verifies it returns false when there are no configured zones.
+- `testIsInForcedPvPZone_InZone`: Verifies it returns true when the location is inside a created zone.
+- `testIsInForcedPvPZone_OutsideZone`: Verifies it returns false when the location is outside all created zones.
+- `testIsInForcedPvPZone_DifferentWorld`: Verifies it returns false when the location is in the same coordinates but a different world.
+
+✨ **Result:**
+The testing gap is addressed. The tests have passed successfully. `ZoneManager` can be safely modified without the fear of breaking the forced PvP zone lookup behavior.

--- a/src/test/java/org/SSoggy/SSoggyPvP/manager/ZoneManagerTest.java
+++ b/src/test/java/org/SSoggy/SSoggyPvP/manager/ZoneManagerTest.java
@@ -1,0 +1,118 @@
+package org.SSoggy.SSoggyPvP.manager;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.Server;
+import org.bukkit.World;
+import org.bukkit.scheduler.BukkitScheduler;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.MockitoAnnotations;
+
+import org.SSoggy.SSoggyPvP.PvPTogglePlugin;
+import org.SSoggy.SSoggyPvP.model.PvPZone;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class ZoneManagerTest {
+
+    @Mock
+    private PvPTogglePlugin plugin;
+
+    private ZoneManager zoneManager;
+    private MockedStatic<Bukkit> mockedBukkit;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+
+        mockedBukkit = mockStatic(Bukkit.class);
+        Server mockServer = mock(Server.class);
+        BukkitScheduler mockScheduler = mock(BukkitScheduler.class);
+
+        when(mockServer.getScheduler()).thenReturn(mockScheduler);
+        mockedBukkit.when(Bukkit::getServer).thenReturn(mockServer);
+        mockedBukkit.when(Bukkit::getScheduler).thenReturn(mockScheduler);
+
+        zoneManager = new ZoneManager(plugin);
+    }
+
+    @AfterEach
+    void tearDown() {
+        mockedBukkit.close();
+    }
+
+    @Test
+    void testIsInForcedPvPZone_NullLocation() {
+        assertFalse(zoneManager.isInForcedPvPZone(null));
+    }
+
+    @Test
+    void testIsInForcedPvPZone_NullWorld() {
+        Location loc = new Location(null, 10, 10, 10);
+        assertFalse(zoneManager.isInForcedPvPZone(loc));
+    }
+
+    @Test
+    void testIsInForcedPvPZone_EmptyZones() {
+        World world = mock(World.class);
+        when(world.getName()).thenReturn("world");
+        Location loc = new Location(world, 10, 10, 10);
+
+        assertFalse(zoneManager.isInForcedPvPZone(loc));
+    }
+
+    @Test
+    void testIsInForcedPvPZone_InZone() {
+        World world = mock(World.class);
+        when(world.getName()).thenReturn("world");
+
+        UUID playerId = UUID.randomUUID();
+        zoneManager.setPosition(playerId, 0, new Location(world, 0, 0, 0));
+        zoneManager.setPosition(playerId, 1, new Location(world, 20, 20, 20));
+
+        assertTrue(zoneManager.createZone("testZone", playerId));
+
+        Location inside = new Location(world, 10, 10, 10);
+        assertTrue(zoneManager.isInForcedPvPZone(inside));
+    }
+
+    @Test
+    void testIsInForcedPvPZone_OutsideZone() {
+        World world = mock(World.class);
+        when(world.getName()).thenReturn("world");
+
+        UUID playerId = UUID.randomUUID();
+        zoneManager.setPosition(playerId, 0, new Location(world, 0, 0, 0));
+        zoneManager.setPosition(playerId, 1, new Location(world, 20, 20, 20));
+
+        assertTrue(zoneManager.createZone("testZone", playerId));
+
+        Location outside = new Location(world, 30, 30, 30);
+        assertFalse(zoneManager.isInForcedPvPZone(outside));
+    }
+
+    @Test
+    void testIsInForcedPvPZone_DifferentWorld() {
+        World world1 = mock(World.class);
+        when(world1.getName()).thenReturn("world");
+
+        World world2 = mock(World.class);
+        when(world2.getName()).thenReturn("world_nether");
+
+        UUID playerId = UUID.randomUUID();
+        zoneManager.setPosition(playerId, 0, new Location(world1, 0, 0, 0));
+        zoneManager.setPosition(playerId, 1, new Location(world1, 20, 20, 20));
+
+        assertTrue(zoneManager.createZone("testZone", playerId));
+
+        Location otherWorldLoc = new Location(world2, 10, 10, 10);
+        assertFalse(zoneManager.isInForcedPvPZone(otherWorldLoc));
+    }
+}


### PR DESCRIPTION
🎯 **What:** 
Added unit tests for the `isInForcedPvPZone` method in `ZoneManager.java`. This method determines if a given location is inside any of the configured PvP zones, but it lacked dedicated tests to ensure its logic correctly checked null inputs, empty zones, inside/outside location logic, and cross-world interactions.

📊 **Coverage:** 
We added the following test scenarios:
- `testIsInForcedPvPZone_NullLocation`: Verifies it returns false for a null Location.
- `testIsInForcedPvPZone_NullWorld`: Verifies it returns false for a Location with a null World.
- `testIsInForcedPvPZone_EmptyZones`: Verifies it returns false when there are no configured zones.
- `testIsInForcedPvPZone_InZone`: Verifies it returns true when the location is inside a created zone.
- `testIsInForcedPvPZone_OutsideZone`: Verifies it returns false when the location is outside all created zones.
- `testIsInForcedPvPZone_DifferentWorld`: Verifies it returns false when the location is in the same coordinates but a different world.

✨ **Result:** 
The testing gap is addressed. The tests have passed successfully. `ZoneManager` can be safely modified without the fear of breaking the forced PvP zone lookup behavior.

---
*PR created automatically by Jules for task [12960415339941699091](https://jules.google.com/task/12960415339941699091) started by @SSoggyTacoMan*