### PR TITLE
🧪 Add error test coverage for YamlUtil.getSafeFile

### DIFF
--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,8 @@
+🎯 **What:** The testing gap addressed
+The `YamlUtil.getSafeFile` method lacked error testing, specifically for cases where path traversal strings like '../config.yml' are provided.
+
+📊 **Coverage:** What scenarios are now tested
+Test cases have been added to verify that `YamlUtil.loadSection` correctly handles and blocks path traversal attempts by returning null. Similarly, `YamlUtil.saveConfig` has been tested to assure it safely rejects inputs attempting to write outside the configured data folder. Additionally, null safety for `dataFolder` and `filename` has been tested.
+
+✨ **Result:** The improvement in test coverage
+The error paths and null guarding within `YamlUtil` now have specific tests, increasing overall code reliability and testing coverage for filesystem operations.

--- a/src/test/java/org/SSoggy/SSoggyPvP/util/YamlUtilTest.java
+++ b/src/test/java/org/SSoggy/SSoggyPvP/util/YamlUtilTest.java
@@ -1,0 +1,47 @@
+package org.SSoggy.SSoggyPvP.util;
+
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.logging.Logger;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class YamlUtilTest {
+
+    @TempDir
+    File dataFolder;
+
+    @Test
+    public void testLoadSectionPathTraversal() {
+        ConfigurationSection section = YamlUtil.loadSection(dataFolder, "../config.yml", "someKey");
+        assertNull(section, "Should return null for path traversal attempt");
+    }
+
+    @Test
+    public void testLoadSectionNullDataFolder() {
+        ConfigurationSection section = YamlUtil.loadSection(null, "config.yml", "someKey");
+        assertNull(section, "Should return null for null data folder");
+    }
+
+    @Test
+    public void testLoadSectionNullFilename() {
+        ConfigurationSection section = YamlUtil.loadSection(dataFolder, null, "someKey");
+        assertNull(section, "Should return null for null filename");
+    }
+
+    @Test
+    public void testSaveConfigPathTraversal() {
+        YamlConfiguration config = new YamlConfiguration();
+        Logger logger = Logger.getLogger("TestLogger");
+        YamlUtil.saveConfig(config, dataFolder, "../config.yml", logger, "Error");
+
+        File file = new File(dataFolder.getParentFile(), "config.yml");
+        org.junit.jupiter.api.Assertions.assertFalse(file.exists(), "Should not create file outside data folder");
+    }
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The `YamlUtil.getSafeFile` method lacked error testing, specifically for cases where path traversal strings like '../config.yml' are provided.

📊 **Coverage:** What scenarios are now tested
Test cases have been added to verify that `YamlUtil.loadSection` correctly handles and blocks path traversal attempts by returning null. Similarly, `YamlUtil.saveConfig` has been tested to assure it safely rejects inputs attempting to write outside the configured data folder. Additionally, null safety for `dataFolder` and `filename` has been tested.

✨ **Result:** The improvement in test coverage
The error paths and null guarding within `YamlUtil` now have specific tests, increasing overall code reliability and testing coverage for filesystem operations.

---
*PR created automatically by Jules for task [10398000485329265382](https://jules.google.com/task/10398000485329265382) started by @SSoggyTacoMan*