### PR TITLE
🧪 Add tests for YamlUtil path traversal protection

### DIFF
--- a/src/test/java/org/SSoggy/SSoggyPvP/util/YamlUtilTest.java
+++ b/src/test/java/org/SSoggy/SSoggyPvP/util/YamlUtilTest.java
@@ -1,0 +1,90 @@
+package org.SSoggy.SSoggyPvP.util;
+
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mockito;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.startsWith;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.verify;
+
+class YamlUtilTest {
+
+    @Test
+    void testPathTraversal_loadSection(@TempDir File dataFolder) {
+        // Path traversal should be blocked and return null
+        assertNull(YamlUtil.loadSection(dataFolder, "../config.yml", "test"));
+        assertNull(YamlUtil.loadSection(dataFolder, "../../etc/passwd", "test"));
+        assertNull(YamlUtil.loadSection(dataFolder, "nested/../../config.yml", "test"));
+    }
+
+    @Test
+    void testPathTraversal_saveConfig(@TempDir File dataFolder) {
+        YamlConfiguration config = new YamlConfiguration();
+        Logger logger = Mockito.mock(Logger.class);
+
+        // Check save config using invalid paths.
+        // It shouldn't create a file outside the dataFolder
+        YamlUtil.saveConfig(config, dataFolder, "../config.yml", logger, "Error");
+        File parentDirFile = new File(dataFolder.getParentFile(), "config.yml");
+        assertFalse(parentDirFile.exists(), "File should not be created outside data folder");
+        verify(logger).log(Level.WARNING, "Blocked potential path traversal attempt while saving: {0}", "../config.yml");
+
+        YamlUtil.saveConfig(config, dataFolder, "../../etc/passwd", logger, "Error");
+        verify(logger).log(Level.WARNING, "Blocked potential path traversal attempt while saving: {0}", "../../etc/passwd");
+
+        YamlUtil.saveConfig(config, dataFolder, "nested/../../config.yml", logger, "Error");
+        verify(logger).log(Level.WARNING, "Blocked potential path traversal attempt while saving: {0}", "nested/../../config.yml");
+    }
+
+    @Test
+    void testValidFile_loadSection(@TempDir File dataFolder) throws IOException {
+        File file = new File(dataFolder, "config.yml");
+        file.createNewFile();
+
+        YamlConfiguration config = YamlConfiguration.loadConfiguration(file);
+        config.set("test.key", "value");
+        config.save(file);
+
+        assertNotNull(YamlUtil.loadSection(dataFolder, "config.yml", "test"));
+    }
+
+    @Test
+    void testValidFile_loadSection_nulls() {
+        assertNull(YamlUtil.loadSection(null, "config.yml", "test"));
+        assertNull(YamlUtil.loadSection(new File("."), null, "test"));
+    }
+
+    @Test
+    void testValidFile_saveConfig(@TempDir File dataFolder) {
+        YamlConfiguration config = new YamlConfiguration();
+        config.set("test.key", "value");
+        Logger logger = Mockito.mock(Logger.class);
+
+        YamlUtil.saveConfig(config, dataFolder, "config.yml", logger, "Error");
+
+        File file = new File(dataFolder, "config.yml");
+        assertTrue(file.exists());
+    }
+
+    @Test
+    void testValidFile_saveConfig_nulls() {
+        YamlConfiguration config = new YamlConfiguration();
+        Logger logger = Mockito.mock(Logger.class);
+
+        YamlUtil.saveConfig(config, null, "config.yml", logger, "Error");
+        verify(logger).log(Level.WARNING, "Blocked potential path traversal attempt while saving: {0}", "config.yml");
+
+        YamlUtil.saveConfig(config, new File("."), null, logger, "Error");
+        verify(logger).log(Level.WARNING, "Blocked potential path traversal attempt while saving: {0}", (Object) null);
+    }
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the missing error testing for `YamlUtil.getSafeFile`, specifically checking if path traversal parameters like `../config.yml` or `../../etc/passwd` correctly throw a warning and get blocked.

📊 **Coverage:** Scenarios covered include:
- Trying to load configs outside the plugin's data folder using the `../` pattern (`../config.yml`, `../../etc/passwd`, etc.) inside `loadSection`.
- Trying to save configs outside the plugin's data folder using the `../` pattern inside `saveConfig`.
- Correct saving and loading function logic tests when passed correctly formatted arguments.
- Handling `null` path or arguments appropriately.

✨ **Result:** A significant improvement in test coverage. The `YamlUtil.getSafeFile` error detection functionality, a major component ensuring path safety inside this plugin, is fully documented by unit tests. This safeguards refactoring operations in this utility class, as path traversal attacks should now safely be detected by testing.

---
*PR created automatically by Jules for task [12992739174526498624](https://jules.google.com/task/12992739174526498624) started by @SSoggyTacoMan*