### PR TITLE
🧹 Fix deprecated getOfflinePlayer usage in PvPAdminCommand

### DIFF
--- a/src/main/java/org/SSoggy/SSoggyPvP/command/PvPAdminCommand.java
+++ b/src/main/java/org/SSoggy/SSoggyPvP/command/PvPAdminCommand.java
@@ -155,7 +155,20 @@ public class PvPAdminCommand implements TabExecutor {
         MessageUtil.send(sender, "&7Corner 2: &f(" + zone.getX2() + ", " + zone.getY2() + ", " + zone.getZ2() + ")");
     }
 
-    @SuppressWarnings("deprecation")
+
+    private OfflinePlayer getOfflinePlayerExact(String name) {
+        Player online = Bukkit.getPlayerExact(name);
+        if (online != null) {
+            return online;
+        }
+        for (OfflinePlayer offline : Bukkit.getOfflinePlayers()) {
+            if (offline.getName() != null && offline.getName().equalsIgnoreCase(name)) {
+                return offline;
+            }
+        }
+        return null;
+    }
+
     private void handlePlayer(CommandSender sender, String[] args) {
         if (args.length < 3) {
             MessageUtil.send(sender, "&cUsage: /pvpadmin player <name> <info|reset|setdebt>");
@@ -163,8 +176,8 @@ public class PvPAdminCommand implements TabExecutor {
         }
 
         String playerName = args[1];
-        OfflinePlayer target = Bukkit.getOfflinePlayer(playerName);
-        if (!target.hasPlayedBefore() && !target.isOnline()) {
+        OfflinePlayer target = getOfflinePlayerExact(playerName);
+        if (target == null || (!target.hasPlayedBefore() && !target.isOnline())) {
             MessageUtil.send(sender, "&cPlayer '&f" + playerName + "&c' has never joined this server.");
             return;
         }

--- a/src/main/java/org/SSoggy/SSoggyPvP/command/PvPAdminCommand.java
+++ b/src/main/java/org/SSoggy/SSoggyPvP/command/PvPAdminCommand.java
@@ -177,7 +177,7 @@ public class PvPAdminCommand implements TabExecutor {
 
         String playerName = args[1];
         OfflinePlayer target = getOfflinePlayerExact(playerName);
-        if (target == null || (!target.hasPlayedBefore() && !target.isOnline())) {
+        if (target == null) {
             MessageUtil.send(sender, "&cPlayer '&f" + playerName + "&c' has never joined this server.");
             return;
         }


### PR DESCRIPTION
🎯 **What:** The deprecated Bukkit.getOfflinePlayer(String) method has been replaced with a private helper method that sequentially looks up exact online matches and locally cached offline players without initiating asynchronous or blocking web requests.
💡 **Why:** The legacy method triggers a potentially blocking call to the Mojang API which can freeze the main server thread. This patch corrects the code smell while preserving the synchronous execution requirements of the command handler.
✅ **Verification:** Recompiled successfully using `mvn clean install` and all tests pass with `mvn test`. Local iterations match the exact functional output.
✨ **Result:** Safe player lookup logic with removal of the `@SuppressWarnings("deprecation")` code smell.

---
*PR created automatically by Jules for task [1229736756543059487](https://jules.google.com/task/1229736756543059487) started by @SSoggyTacoMan*